### PR TITLE
Добавлено 19 дз

### DIFF
--- a/hw19/cmd/gosearch/main.go
+++ b/hw19/cmd/gosearch/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"sync"
+
+	"gosearch/pkg/api"
+	"gosearch/pkg/crawler"
+	"gosearch/pkg/crawler/spider"
+	"gosearch/pkg/engine"
+	"gosearch/pkg/index/tree"
+	"gosearch/pkg/rpcsrv"
+
+	"github.com/gorilla/mux"
+)
+
+type gosearch struct {
+	crawler crawler.Interface
+	engine  *engine.Service
+	api     *api.Service
+	rpcsrv  *rpcsrv.RPCsrv
+}
+
+func (g *gosearch) scanAsync(urls []string, depth int) {
+	dataCh, errCh := g.crawler.BatchScan(urls, depth, 10)
+	var data []crawler.Document
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for err := range errCh {
+			log.Printf("ошибка при получении данных с сайта: %s\n", err.Error())
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for doc := range dataCh {
+			data = append(data, doc)
+		}
+	}()
+	wg.Wait()
+
+	tree := tree.NewTree(data)
+	g.engine = engine.New(tree, data)
+	g.api = api.New(mux.NewRouter(), g.engine)
+}
+
+func main() {
+	urls := []string{"https://habr.com", "https://go.dev", "https://golang.org/"}
+	port := "8000"
+	rpcport := "8001"
+	host := "0.0.0.0"
+
+	tree := tree.NewTree([]crawler.Document{})
+
+	spdr := spider.New()
+	engn := engine.New(tree, []crawler.Document{})
+
+	app := &gosearch{
+		crawler: spdr,
+		engine:  engn,
+		api:     api.New(mux.NewRouter(), engn),
+	}
+
+	app.scanAsync(urls, 1)
+	go rpcsrv.Serve(host, rpcport, app.engine)
+
+	http.ListenAndServe(host+":"+port, app.api.Router)
+}

--- a/hw19/cmd/netclient/main.go
+++ b/hw19/cmd/netclient/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"strings"
+)
+
+func main() {
+	host := "localhost"
+	port := "8000"
+
+	conn, err := net.Dial("tcp4", host+":"+port)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	enter := "Enter word to find: "
+	snr := bufio.NewScanner(os.Stdin)
+
+	for fmt.Print(enter); snr.Scan(); fmt.Print(enter) {
+		word := snr.Text()
+		if strings.Replace(word, " ", "", -1) == "exit" {
+			break
+		}
+		if word != "" {
+			_, err := conn.Write([]byte(word + "\n"))
+			if err != nil {
+				log.Fatalf("writing error: %s", err.Error())
+			}
+		}
+
+		rdr := bufio.NewReader(conn)
+		for {
+			res, err := rdr.ReadString('\n')
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				log.Fatalf("error occured: %s", err.Error())
+			}
+
+			fmt.Println(res)
+			if res == "done\n" || strings.Contains(res, "error occured") {
+				break
+			}
+		}
+	}
+}

--- a/hw19/cmd/rpcclient/main.go
+++ b/hw19/cmd/rpcclient/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"gosearch/pkg/crawler"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/powerman/rpc-codec/jsonrpc2"
+)
+
+type Query struct {
+	Data string
+}
+
+func main() {
+	host := "0.0.0.0"
+	port := "8001"
+
+	conn, err := jsonrpc2.Dial("tcp", host+":"+port)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	defer conn.Close()
+
+	enter := "Enter word to find: "
+	snr := bufio.NewScanner(os.Stdin)
+
+	for fmt.Print(enter); snr.Scan(); fmt.Print(enter) {
+		word := snr.Text()
+		if strings.Replace(word, " ", "", -1) == "exit" {
+			break
+		}
+
+		if word != "" {
+			res := []crawler.Document{}
+			query := Query{Data: word}
+
+			err = jsonrpc2.WrapError(conn.Call("RPCsrv.Search", query, &res))
+			if err != nil {
+				log.Printf("error: %q\n", err)
+			}
+
+			fmt.Println(res)
+		}
+	}
+}

--- a/hw19/cmd/rpcclient/main.go
+++ b/hw19/cmd/rpcclient/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/powerman/rpc-codec/jsonrpc2"
+	"net/rpc/jsonrpc"
 )
 
 type Query struct {
@@ -19,7 +19,7 @@ func main() {
 	host := "0.0.0.0"
 	port := "8001"
 
-	conn, err := jsonrpc2.Dial("tcp", host+":"+port)
+	conn, err := jsonrpc.Dial("tcp", host+":"+port)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
@@ -38,7 +38,7 @@ func main() {
 			res := []crawler.Document{}
 			query := Query{Data: word}
 
-			err = jsonrpc2.WrapError(conn.Call("RPCsrv.Search", query, &res))
+			err = conn.Call("RPCsrv.Search", query, &res)
 			if err != nil {
 				log.Printf("error: %q\n", err)
 			}

--- a/hw19/go.mod
+++ b/hw19/go.mod
@@ -1,0 +1,35 @@
+module gosearch
+
+go 1.15
+
+replace (
+	gosearch/pkg/api => ./pkg/api
+	gosearch/pkg/crawler v0.0.0 => ./pkg/crawler
+	gosearch/pkg/crawler/spider v0.0.0 => ./pkg/crawler/spider
+
+	gosearch/pkg/engine v0.0.0 => ./pkg/engine
+	gosearch/pkg/index v0.0.0 => ./pkg/index
+
+	gosearch/pkg/index/tree v0.0.0 => ./pkg/index/tree
+	gosearch/pkg/index/tree/btree => ./pkg/index/tree/btree
+
+	gosearch/pkg/netsrv => ./pkg/netsrv
+	gosearch/pkg/rpcsrv => ./pkg/rpcsrv
+	gosearch/pkg/webapp => ./pkg/webapp
+
+)
+
+require (
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/gorilla/rpc v1.2.0 // indirect
+	github.com/powerman/rpc-codec v1.2.2
+	golang.org/x/net v0.0.0-20201224014010-6772e930b67b // indirect
+	gosearch/pkg/api v0.0.0-00010101000000-000000000000 // indirect
+	gosearch/pkg/crawler v0.0.0
+	gosearch/pkg/crawler/spider v0.0.0 // indirect
+	gosearch/pkg/engine v0.0.0 // indirect
+	gosearch/pkg/index v0.0.0 // indirect
+	gosearch/pkg/index/tree v0.0.0 // indirect
+	gosearch/pkg/index/tree/btree v0.0.0-00010101000000-000000000000 // indirect
+	gosearch/pkg/rpcsrv v0.0.0-00010101000000-000000000000 // indirect
+)

--- a/hw19/go.mod
+++ b/hw19/go.mod
@@ -16,16 +16,13 @@ replace (
 	gosearch/pkg/netsrv => ./pkg/netsrv
 	gosearch/pkg/rpcsrv => ./pkg/rpcsrv
 	gosearch/pkg/webapp => ./pkg/webapp
-
 )
 
 require (
 	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/gorilla/rpc v1.2.0 // indirect
-	github.com/powerman/rpc-codec v1.2.2
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b // indirect
 	gosearch/pkg/api v0.0.0-00010101000000-000000000000 // indirect
-	gosearch/pkg/crawler v0.0.0
+	gosearch/pkg/crawler v0.0.0 // indirect
 	gosearch/pkg/crawler/spider v0.0.0 // indirect
 	gosearch/pkg/engine v0.0.0 // indirect
 	gosearch/pkg/index v0.0.0 // indirect

--- a/hw19/go.sum
+++ b/hw19/go.sum
@@ -1,0 +1,12 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/rpc v1.2.0 h1:WvvdC2lNeT1SP32zrIce5l0ECBfbAlmrmSBsuc57wfk=
+github.com/gorilla/rpc v1.2.0/go.mod h1:V4h9r+4sF5HnzqbwIez0fKSpANP0zlYd3qR7p36jkTQ=
+github.com/powerman/rpc-codec v1.2.2 h1:BK0JScZivljhwW/vLLhZLtUgqSxc/CD3sHEs8LiwwKw=
+github.com/powerman/rpc-codec v1.2.2/go.mod h1:3Qr/y/+u3CwcSww9tfJMRn/95lB2qUdUeIQe7BYlLDo=
+golang.org/x/net v0.0.0-20201224014010-6772e930b67b h1:iFwSg7t5GZmB/Q5TjiEAsdoLDrdJRC1RiF2WhuV29Qw=
+golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/hw19/go.sum
+++ b/hw19/go.sum
@@ -1,9 +1,5 @@
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/rpc v1.2.0 h1:WvvdC2lNeT1SP32zrIce5l0ECBfbAlmrmSBsuc57wfk=
-github.com/gorilla/rpc v1.2.0/go.mod h1:V4h9r+4sF5HnzqbwIez0fKSpANP0zlYd3qR7p36jkTQ=
-github.com/powerman/rpc-codec v1.2.2 h1:BK0JScZivljhwW/vLLhZLtUgqSxc/CD3sHEs8LiwwKw=
-github.com/powerman/rpc-codec v1.2.2/go.mod h1:3Qr/y/+u3CwcSww9tfJMRn/95lB2qUdUeIQe7BYlLDo=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b h1:iFwSg7t5GZmB/Q5TjiEAsdoLDrdJRC1RiF2WhuV29Qw=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/hw19/pkg/api/api.go
+++ b/hw19/pkg/api/api.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"encoding/json"
+	"gosearch/pkg/crawler"
+	"gosearch/pkg/engine"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+type Service struct {
+	Router *mux.Router
+	engine *engine.Service
+}
+
+func New(router *mux.Router, engine *engine.Service) *Service {
+	s := Service{
+		Router: router,
+		engine: engine,
+	}
+	s.endpoints()
+
+	return &s
+}
+
+func (s *Service) endpoints() {
+	s.Router.HandleFunc("/api/search/{query}", s.Search).Methods(http.MethodGet)
+	s.Router.HandleFunc("/api/docs", s.Docs).Methods(http.MethodGet)
+	s.Router.HandleFunc("/api/create_doc", s.Create).Methods(http.MethodPost)
+	s.Router.HandleFunc("/api/delete_doc", s.Delete).Methods(http.MethodPost)
+	s.Router.HandleFunc("/api/update_doc", s.Update).Methods(http.MethodPost)
+}
+
+func (s *Service) Search(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "application/json")
+
+	query := mux.Vars(r)["query"]
+	result, err := s.engine.Search(query)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(result)
+}
+
+func (s *Service) Docs(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "application/json")
+
+	json.NewEncoder(w).Encode(s.engine.Data)
+}
+
+func (s *Service) Create(w http.ResponseWriter, r *http.Request) {
+	var req crawler.Document
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	r.Body.Close()
+
+	if req.Title == "" || req.URL == "" {
+		http.Error(w, `"url", "title" fields should not be empty`, http.StatusBadRequest)
+		return
+	}
+
+	err = s.engine.Tree.Add(req.URL, req.Title)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+}
+
+func (s *Service) Delete(w http.ResponseWriter, r *http.Request) {
+	var req crawler.Document
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	r.Body.Close()
+
+	if req.ID == 0 {
+		http.Error(w, `"id" field should not be empty`, http.StatusBadRequest)
+		return
+	}
+
+	err = s.engine.Tree.Delete(req.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+}
+
+func (s *Service) Update(w http.ResponseWriter, r *http.Request) {
+	var req crawler.Document
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	r.Body.Close()
+
+	if req.ID == 0 || req.URL == "" || req.Title == "" {
+		http.Error(w, `"url", "title", "id" fields should not be empty`, http.StatusBadRequest)
+		return
+	}
+
+	err = s.engine.Tree.Update(req.ID, req.URL, req.Title)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+}

--- a/hw19/pkg/api/api_test.go
+++ b/hw19/pkg/api/api_test.go
@@ -1,0 +1,326 @@
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"github.com/gorilla/mux"
+	"gosearch/pkg/crawler"
+	"gosearch/pkg/engine"
+	"gosearch/pkg/index/fakeindex"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+var (
+	s    = &Service{}
+	data = []crawler.Document{
+		crawler.Document{
+			ID:    uint64(1),
+			Title: "Как использовать git?",
+			URL:   "http://localhost1",
+		},
+		crawler.Document{
+			ID:    uint64(2),
+			Title: "Прикладное применение подорожника как лекарство",
+			URL:   "http://localhost2",
+		},
+		crawler.Document{
+			ID:    uint64(3),
+			Title: "Криптовалюта как будущее финансовой системы?",
+			URL:   "http://localhost3",
+		},
+	}
+)
+
+type Case struct {
+	Method  string
+	Path    string
+	Status  int
+	Result  []crawler.Document
+	Payload map[string]interface{}
+	wantErr bool
+	Error   string
+}
+
+func TestMain(m *testing.M) {
+	fi := fakeindex.New(data)
+	s = New(mux.NewRouter(), engine.New(fi, data))
+	s.endpoints()
+
+	exitVal := m.Run()
+	os.Exit(exitVal)
+}
+
+func TestSearch(t *testing.T) {
+	tests := []Case{
+		Case{
+			Method:  http.MethodGet,
+			Path:    "/api/search/git",
+			Status:  http.StatusOK,
+			wantErr: false,
+			Result: []crawler.Document{
+				crawler.Document{
+					ID:    uint64(1),
+					Title: "Как использовать git?",
+					URL:   "http://localhost1",
+				},
+			},
+		},
+		Case{
+			Method:  http.MethodGet,
+			Path:    "/api/search/go",
+			Status:  http.StatusInternalServerError,
+			wantErr: true,
+			Error:   "document not found\n",
+		},
+	}
+
+	for idx, tt := range tests {
+		var req *http.Request
+		if tt.Method == http.MethodPost {
+			payload, _ := json.Marshal(tt.Payload)
+			req = httptest.NewRequest(tt.Method, tt.Path, bytes.NewBuffer(payload))
+		}
+		if tt.Method == http.MethodGet {
+			req = httptest.NewRequest(tt.Method, tt.Path, &bufio.Reader{})
+		}
+		rr := httptest.NewRecorder()
+
+		s.Router.ServeHTTP(rr, req)
+
+		if rr.Code != tt.Status {
+			t.Fatalf("[%d] >>> код неверен: получили %d, а хотели %d", idx, rr.Code, tt.Status)
+		}
+
+		if tt.wantErr {
+			resp, err := ioutil.ReadAll(rr.Body)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if string(resp) != tt.Error {
+				t.Fatalf("[%d] >>> ответ неверен: получили %s, а хотели %s", idx, resp, tt.Error)
+			}
+		}
+
+		if !tt.wantErr {
+			var resp []crawler.Document
+			err := json.NewDecoder(rr.Body).Decode(&resp)
+			if err != nil {
+				t.Fatalf("[%d] >>> ответ неверен: не удается преобразовать ответ в структуру документа: %s", idx, err.Error())
+			}
+
+			if tt.Result[0] != resp[0] {
+				t.Fatalf("[%d] >>> ответ неверен: получили %+v, а хотели %+v", idx, resp[0], tt.Result[0])
+			}
+		}
+	}
+}
+
+func TestDocs(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/docs", &bufio.Reader{})
+
+	rr := httptest.NewRecorder()
+
+	s.Router.ServeHTTP(rr, req)
+
+	if rr.Code != 200 {
+		t.Errorf("код неверен: получили %d, а хотели %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestCreate(t *testing.T) {
+	tests := []Case{
+		Case{
+			Method:  http.MethodPost,
+			Path:    "/api/create_doc",
+			Status:  http.StatusOK,
+			wantErr: false,
+			Payload: map[string]interface{}{
+				"url":   "http://localhost",
+				"title": "New record",
+			},
+		},
+		Case{
+			Method:  http.MethodPost,
+			Path:    "/api/create_doc",
+			Status:  http.StatusInternalServerError,
+			wantErr: true,
+			Error:   "cannot unmarshal",
+			Payload: map[string]interface{}{
+				"url":   1,
+				"title": "New record",
+			},
+		},
+	}
+
+	for idx, tt := range tests {
+		var req *http.Request
+		if tt.Method == http.MethodPost {
+			payload, _ := json.Marshal(tt.Payload)
+			req = httptest.NewRequest(tt.Method, tt.Path, bytes.NewBuffer(payload))
+		}
+		if tt.Method == http.MethodGet {
+			req = httptest.NewRequest(tt.Method, tt.Path, &bufio.Reader{})
+		}
+		rr := httptest.NewRecorder()
+
+		s.Router.ServeHTTP(rr, req)
+
+		if rr.Code != tt.Status {
+			t.Fatalf("[%d] >>> код неверен: получили %d, а хотели %d", idx, rr.Code, tt.Status)
+		}
+
+		if tt.wantErr {
+			resp, err := ioutil.ReadAll(rr.Body)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if !strings.Contains(string(resp), tt.Error) {
+				t.Fatalf("[%d] >>> ответ неверен: получили %s, а хотели %s", idx, resp, tt.Error)
+			}
+		}
+
+		if !tt.wantErr {
+			_, err := s.engine.Search(tt.Payload["title"].(string))
+			if err != nil {
+				t.Fatalf("[%d] >>> результат неверен: не удается найти добавленный документ: %s", idx, err.Error())
+			}
+		}
+	}
+}
+
+func TestDelete(t *testing.T) {
+	tests := []Case{
+		Case{
+			Method:  http.MethodPost,
+			Path:    "/api/delete_doc",
+			Status:  http.StatusOK,
+			wantErr: false,
+			Result: []crawler.Document{
+				crawler.Document{
+					ID:    uint64(1),
+					Title: "Как использовать git?",
+					URL:   "http://localhost1",
+				},
+			},
+			Payload: map[string]interface{}{
+				"id": 1,
+			},
+		},
+		Case{
+			Method:  http.MethodPost,
+			Path:    "/api/delete_doc",
+			Status:  http.StatusInternalServerError,
+			wantErr: true,
+			Error:   "cannot unmarshal",
+			Payload: map[string]interface{}{
+				"id": "1",
+			},
+		},
+	}
+
+	for idx, tt := range tests {
+		var req *http.Request
+		if tt.Method == http.MethodPost {
+			payload, _ := json.Marshal(tt.Payload)
+			req = httptest.NewRequest(tt.Method, tt.Path, bytes.NewBuffer(payload))
+		}
+		if tt.Method == http.MethodGet {
+			req = httptest.NewRequest(tt.Method, tt.Path, &bufio.Reader{})
+		}
+		rr := httptest.NewRecorder()
+
+		s.Router.ServeHTTP(rr, req)
+
+		if rr.Code != tt.Status {
+			t.Fatalf("[%d] >>> код неверен: получили %d, а хотели %d", idx, rr.Code, tt.Status)
+		}
+
+		if tt.wantErr {
+			resp, err := ioutil.ReadAll(rr.Body)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if !strings.Contains(string(resp), tt.Error) {
+				t.Fatalf("[%d] >>> ответ неверен: получили %s, а хотели %s", idx, resp, tt.Error)
+			}
+		}
+
+		if !tt.wantErr {
+			_, err := s.engine.Search(tt.Result[0].Title)
+			if err == nil {
+				t.Fatalf("[%d] >>> результат неверен: удается найти удаленный документ", idx)
+			}
+		}
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	tests := []Case{
+		Case{
+			Method:  http.MethodPost,
+			Path:    "/api/update_doc",
+			Status:  http.StatusOK,
+			wantErr: false,
+			Payload: map[string]interface{}{
+				"id":    3,
+				"url":   "http://localhost3",
+				"title": "Золото как будущее финансовой системы?",
+			},
+		},
+		Case{
+			Method:  http.MethodPost,
+			Path:    "/api/update_doc",
+			Status:  http.StatusInternalServerError,
+			wantErr: true,
+			Error:   "cannot unmarshal",
+			Payload: map[string]interface{}{
+				"id":    "1",
+				"url":   "http://localhost",
+				"title": "New record",
+			},
+		},
+	}
+
+	for idx, tt := range tests {
+		var req *http.Request
+		if tt.Method == http.MethodPost {
+			payload, _ := json.Marshal(tt.Payload)
+			req = httptest.NewRequest(tt.Method, tt.Path, bytes.NewBuffer(payload))
+		}
+		if tt.Method == http.MethodGet {
+			req = httptest.NewRequest(tt.Method, tt.Path, &bufio.Reader{})
+		}
+		rr := httptest.NewRecorder()
+
+		s.Router.ServeHTTP(rr, req)
+
+		if rr.Code != tt.Status {
+			res, _ := ioutil.ReadAll(rr.Body)
+			t.Log(string(res))
+			t.Fatalf("[%d] >>> код неверен: получили %d, а хотели %d", idx, rr.Code, tt.Status)
+		}
+
+		if tt.wantErr {
+			resp, err := ioutil.ReadAll(rr.Body)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if !strings.Contains(string(resp), tt.Error) {
+				t.Fatalf("[%d] >>> ответ неверен: получили %s, а хотели %s", idx, resp, tt.Error)
+			}
+		}
+
+		if !tt.wantErr {
+			_, err := s.engine.Search(tt.Payload["title"].(string))
+			if err != nil {
+				t.Fatalf("[%d] >>> результат неверен: не удается найти обновленный документ: %s", idx, err.Error())
+			}
+		}
+	}
+}

--- a/hw19/pkg/api/go.mod
+++ b/hw19/pkg/api/go.mod
@@ -1,0 +1,10 @@
+module gosearch/pkg/api
+
+go 1.15
+
+replace (
+	gosearch/pkg/crawler => ../crawler
+	gosearch/pkg/engine => ../engine
+	gosearch/pkg/index => ../index
+	gosearch/pkg/index/fakeindex => ../index/fakeindex
+)

--- a/hw19/pkg/api/go.sum
+++ b/hw19/pkg/api/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/hw19/pkg/crawler/crawler.go
+++ b/hw19/pkg/crawler/crawler.go
@@ -1,0 +1,16 @@
+package crawler
+
+type Interface interface {
+	BatchScan([]string, int, int) (chan Document, chan error)
+	Scan(string, int) ([]Document, error)
+}
+
+type Document struct {
+	ID    uint64
+	Title string
+	URL   string
+}
+
+func (d Document) Ident() uint64 {
+	return d.ID
+}

--- a/hw19/pkg/crawler/fakebot/fakebot.go
+++ b/hw19/pkg/crawler/fakebot/fakebot.go
@@ -1,0 +1,26 @@
+package fakebot
+
+import (
+	"gosearch/pkg/crawler"
+)
+
+type Scan struct{}
+
+func New() *Scan {
+	return &Scan{}
+}
+
+func (l *Scan) Scan(url string, depth int) ([]crawler.Document, error) {
+	data := []crawler.Document{
+		{
+			URL:   "https://habr.ru",
+			Title: "Главная",
+		},
+		{
+			URL:   "https://habr.ru/contact",
+			Title: "Контакты",
+		},
+	}
+
+	return data, nil
+}

--- a/hw19/pkg/crawler/fakebot/go.mod
+++ b/hw19/pkg/crawler/fakebot/go.mod
@@ -1,0 +1,5 @@
+module gosearch/pkg/crawler/fakebot
+
+go 1.15
+
+replace gosearch/pkg/crawler => ../

--- a/hw19/pkg/crawler/go.mod
+++ b/hw19/pkg/crawler/go.mod
@@ -1,0 +1,3 @@
+module gosearch/pkg/crawler
+
+go 1.15

--- a/hw19/pkg/crawler/spider/go.mod
+++ b/hw19/pkg/crawler/spider/go.mod
@@ -1,0 +1,5 @@
+module gosearch/pkg/crawler/spider
+
+go 1.15
+
+replace gosearch/pkg/crawler => ../

--- a/hw19/pkg/crawler/spider/spider.go
+++ b/hw19/pkg/crawler/spider/spider.go
@@ -1,0 +1,153 @@
+// Package spider реализует сканер содержимого веб-сайтов.
+// Пакет позволяет получить список ссылок и заголовков страниц внутри веб-сайта по его URL.
+package spider
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+
+	"gosearch/pkg/crawler"
+
+	"golang.org/x/net/html"
+)
+
+type WebScan struct{}
+
+func New() *WebScan {
+	return &WebScan{}
+}
+
+// BatchScan осуществляет одновременное сканирование нескольких ссылок, передаваемых в urls.
+// Используется конкурентный шаблон workers pool.
+// Возвращает канал ошибок и канал с отсканированными документами
+func (w *WebScan) BatchScan(urls []string, depth int, workers int) (chan crawler.Document, chan error) {
+	jobCh := make(chan string)
+	resCh := make(chan crawler.Document)
+	errCh := make(chan error)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for url := range jobCh {
+				data, err := w.Scan(url, depth)
+				if err != nil {
+					errCh <- err
+					return
+				}
+
+				for _, doc := range data {
+					resCh <- doc
+				}
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(resCh)
+		close(errCh)
+	}()
+
+	go func() {
+		for _, url := range urls {
+			jobCh <- url
+		}
+		close(jobCh)
+	}()
+
+	return resCh, errCh
+}
+
+// Scan осуществляет рекурсивный обход ссылок сайта, указанного в URL,
+// с учётом глубины перехода по ссылкам, переданной в depth.
+func (w *WebScan) Scan(url string, depth int) (data []crawler.Document, err error) {
+	pages := make(map[string]string)
+
+	parse(url, url, depth, pages)
+
+	for url, title := range pages {
+		item := crawler.Document{
+			URL:   url,
+			Title: title,
+		}
+		data = append(data, item)
+	}
+
+	return data, nil
+}
+
+// parse рекурсивно обходит ссылки на странице, переданной в url.
+// Глубина рекурсии задаётся в depth.
+// Каждая найденная ссылка записывается в ассоциативный массив
+// data вместе с названием страницы.
+func parse(url, baseurl string, depth int, data map[string]string) error {
+	if depth == 0 {
+		return nil
+	}
+
+	response, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	page, err := html.Parse(response.Body)
+	if err != nil {
+		return err
+	}
+
+	data[url] = pageTitle(page)
+
+	links := pageLinks(nil, page)
+	for _, link := range links {
+		if data[link] == "" && strings.HasPrefix(link, baseurl) {
+			parse(link, baseurl, depth-1, data)
+		}
+	}
+
+	return nil
+}
+
+// pageTitle осуществляет рекурсивный обход HTML-страницы и возвращает значение элемента <tittle>.
+func pageTitle(n *html.Node) string {
+	var title string
+	if n.Type == html.ElementNode && n.Data == "title" {
+		return n.FirstChild.Data
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		title = pageTitle(c)
+		if title != "" {
+			break
+		}
+	}
+	return title
+}
+
+// pageLinks рекурсивно сканирует узлы HTML-страницы и возвращает все найденные ссылки без дубликатов.
+func pageLinks(links []string, n *html.Node) []string {
+	if n.Type == html.ElementNode && n.Data == "a" {
+		for _, a := range n.Attr {
+			if a.Key == "href" {
+				if !sliceContains(links, a.Val) {
+					links = append(links, a.Val)
+				}
+			}
+		}
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		links = pageLinks(links, c)
+	}
+	return links
+}
+
+// sliceContains возвращает true если массив содержит переданное значение
+func sliceContains(slice []string, value string) bool {
+	for _, v := range slice {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}

--- a/hw19/pkg/crawler/spider/spider_test.go
+++ b/hw19/pkg/crawler/spider/spider_test.go
@@ -1,0 +1,31 @@
+// Package spider реализует сканер содержимого веб-сайтов.
+
+// Пакет позволяет получить список ссылок и заголовков страниц внутри веб-сайта по его URL.
+
+package spider
+
+import (
+	"flag"
+	"testing"
+)
+
+var online = flag.Bool("online", false, "only perform local tests")
+
+// Для запуска теста требуется фалг -online=true
+func TestScan(t *testing.T) {
+	if !*online {
+		t.Skip()
+	}
+	const url = "https://habr.com"
+	const depth = 1
+
+	sp := New()
+	data, err := sp.Scan(url, depth)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, v := range data {
+		t.Logf("%s -> %s\n", v.Title, v.URL)
+	}
+}

--- a/hw19/pkg/engine/engine.go
+++ b/hw19/pkg/engine/engine.go
@@ -1,0 +1,30 @@
+package engine
+
+import (
+	"fmt"
+	"gosearch/pkg/crawler"
+	"gosearch/pkg/index"
+)
+
+type Service struct {
+	Tree index.Interface
+	Data []crawler.Document
+}
+
+func New(index index.Interface, data []crawler.Document) *Service {
+	return &Service{
+		Tree: index,
+		Data: data,
+	}
+}
+
+func (s *Service) Search(query string) ([]crawler.Document, error) {
+	if query == "" {
+		return nil, fmt.Errorf("пустой запрос")
+	}
+	docs, err := s.Tree.Find(query)
+	if err != nil {
+		return nil, err
+	}
+	return docs, nil
+}

--- a/hw19/pkg/engine/engine_test.go
+++ b/hw19/pkg/engine/engine_test.go
@@ -1,0 +1,80 @@
+package engine
+
+import (
+	"gosearch/pkg/crawler"
+	"gosearch/pkg/index"
+	"gosearch/pkg/index/fakeindex"
+	"reflect"
+	"testing"
+)
+
+func TestService_Search(t *testing.T) {
+	want := []crawler.Document{
+		crawler.Document{
+			ID:    uint64(1),
+			Title: "Как использовать git?",
+			URL:   "http://localhost",
+		},
+		crawler.Document{
+			ID:    uint64(2),
+			Title: "Прикладное применение подорожника как лекарство",
+			URL:   "http://localhost",
+		},
+		crawler.Document{
+			ID:    uint64(3),
+			Title: "Криптовалюта как будущее финансовой системы?",
+			URL:   "http://localhost",
+		},
+	}
+	type fields struct {
+		Index index.Interface
+	}
+	type args struct {
+		query string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []crawler.Document
+		wantErr bool
+	}{
+		{
+			name: "Тестирование поиска",
+			fields: fields{
+				fakeindex.New(),
+			},
+			args: args{
+				"как",
+			},
+			want:    want,
+			wantErr: false,
+		},
+		{
+			name: "Тестирование поиска пустого запроса",
+			fields: fields{
+				fakeindex.New(),
+			},
+			args: args{
+				"",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{
+				Index: tt.fields.Index,
+			}
+			got, err := s.Search(tt.args.query)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Service.Search() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Service.Search() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/hw19/pkg/engine/go.mod
+++ b/hw19/pkg/engine/go.mod
@@ -1,0 +1,8 @@
+module gosearch/pkg/engine
+
+replace (
+	gosearch/pkg/crawler => ../crawler
+	gosearch/pkg/index => ../index
+)
+
+go 1.15

--- a/hw19/pkg/index/fakeindex/fakeindex.go
+++ b/hw19/pkg/index/fakeindex/fakeindex.go
@@ -1,0 +1,86 @@
+package fakeindex
+
+import (
+	"fmt"
+	"gosearch/pkg/crawler"
+	"gosearch/pkg/index"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+var r = rand.New(rand.NewSource(time.Now().Unix()))
+
+type FakeIndex struct {
+	index index.Index
+	docs  []crawler.Document
+}
+
+func New(data []crawler.Document) *FakeIndex {
+	return &FakeIndex{
+		docs: data,
+	}
+}
+
+func (f *FakeIndex) Add(url string, title string) error {
+	f.docs = append(f.docs, crawler.Document{
+		ID:    r.Uint64(),
+		Title: title,
+		URL:   url,
+	})
+	return nil
+}
+
+func (f *FakeIndex) Delete(ID uint64) error {
+	var isDeleted bool = false
+
+	for i, doc := range f.docs {
+		if doc.ID == ID {
+			isDeleted = true
+			f.docs[i] = f.docs[len(f.docs)-1]
+			f.docs[len(f.docs)-1] = crawler.Document{}
+			f.docs = f.docs[:len(f.docs)-1]
+		}
+	}
+
+	if !isDeleted {
+		return fmt.Errorf("document not found")
+	}
+	return nil
+}
+
+func (f *FakeIndex) Update(ID uint64, url, title string) error {
+	var isUpdated bool = false
+
+	for i, doc := range f.docs {
+		if doc.ID == ID {
+			isUpdated = true
+			f.docs[i].Title = title
+			f.docs[i].URL = url
+		}
+	}
+
+	if !isUpdated {
+		return fmt.Errorf("document not found")
+	}
+	return nil
+}
+
+func (f *FakeIndex) Index() index.Index {
+	return index.Index{"как": []uint64{1123123, 12432343, 1242544}}
+}
+
+func (f *FakeIndex) Find(request string) ([]crawler.Document, error) {
+	var docs []crawler.Document
+
+	for _, doc := range f.docs {
+		if strings.Contains(doc.Title, request) {
+			docs = append(docs, doc)
+		}
+	}
+
+	if len(docs) == 0 {
+		return nil, fmt.Errorf("document not found")
+	}
+	return docs, nil
+}

--- a/hw19/pkg/index/fakeindex/go.mod
+++ b/hw19/pkg/index/fakeindex/go.mod
@@ -1,0 +1,9 @@
+module gosearch/pkg/index/fakeindex
+
+replace (
+	gosearch/pkg/crawler => ../../crawler
+	gosearch/pkg/index/tree/btree => ../tree/btree
+)
+
+
+go 1.15

--- a/hw19/pkg/index/go.mod
+++ b/hw19/pkg/index/go.mod
@@ -1,0 +1,7 @@
+module gosearch/pkg/index
+
+replace (
+    gosearch/pkg/crawler => ../crawler
+)
+
+go 1.15

--- a/hw19/pkg/index/index.go
+++ b/hw19/pkg/index/index.go
@@ -1,0 +1,15 @@
+package index
+
+import (
+	"gosearch/pkg/crawler"
+)
+
+type Index map[string][]uint64
+
+type Interface interface {
+	Find(string) ([]crawler.Document, error)
+	Index() Index
+	Add(string, string) error
+	Delete(uint64) error
+	Update(uint64, string, string) error
+}

--- a/hw19/pkg/index/tree/btree/btree.go
+++ b/hw19/pkg/index/tree/btree/btree.go
@@ -1,0 +1,180 @@
+package btree
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+)
+
+type Valuer interface {
+	Ident() uint64
+}
+
+type Tree struct {
+	Left  *Tree
+	Value Valuer
+	Right *Tree
+}
+
+func New() *Tree {
+	return &Tree{
+		Left:  nil,
+		Value: nil,
+		Right: nil,
+	}
+}
+
+func (t *Tree) Add(d Valuer) error {
+	if _, ok := d.(Valuer); !ok {
+		return errors.New("the passed argument does not implement the interface Valuer")
+	}
+	if isNilFixed(d) {
+		return errors.New("element is nil")
+	}
+	if t == nil {
+		return errors.New("tree is nil")
+	}
+	if t.Value == nil {
+		t.Value = d
+		return nil
+	}
+
+	if d.(Valuer).Ident() == t.Value.Ident() {
+		return errors.New("element already exist")
+	}
+	if d.(Valuer).Ident() < t.Value.Ident() {
+		if t.Left == nil {
+			t.Left = &Tree{
+				Left:  nil,
+				Value: d,
+				Right: nil,
+			}
+			return nil
+		}
+		t.Left.Add(d)
+	}
+	if d.(Valuer).Ident() > t.Value.Ident() {
+		if t.Right == nil {
+			t.Right = &Tree{
+				Left:  nil,
+				Value: d,
+				Right: nil,
+			}
+			return nil
+		}
+		t.Right.Add(d)
+	}
+	return nil
+}
+
+func (t *Tree) Min() Valuer {
+	if t.Left == nil {
+		return t.Value
+	}
+	return t.Left.Min()
+}
+
+func (t *Tree) Delete(d Valuer) (*Tree, error) {
+	if _, ok := d.(Valuer); !ok {
+		return nil, errors.New("the passed argument does not implement the interface Valuer")
+	}
+	if isNilFixed(d) {
+		return nil, errors.New("element is nil")
+	}
+
+	if t.Value.Ident() > d.Ident() {
+		t.Left, _ = t.Left.Delete(d)
+	}
+	if t.Value.Ident() < d.Ident() {
+		t.Right, _ = t.Right.Delete(d)
+	}
+	if t.Value.Ident() == d.Ident() {
+		if t.Left == nil {
+			return t.Right, nil
+		}
+		if t.Right == nil {
+			return t.Left, nil
+		}
+
+		min := t.Right.Min()
+
+		t.Value = min
+		t.Right.Delete(min)
+	}
+	return t, nil
+}
+
+func (t *Tree) Update(d Valuer) error {
+	if _, ok := d.(Valuer); !ok {
+		return errors.New("the passed argument does not implement the interface Valuer")
+	}
+	if isNilFixed(d) {
+		return errors.New("element is nil")
+	}
+	if t == nil {
+		return errors.New("document not found")
+	}
+
+	if t.Value.Ident() == d.(Valuer).Ident() {
+		t.Value = d
+		return nil
+	}
+
+	if d.(Valuer).Ident() < t.Value.Ident() {
+		t.Left.Update(d)
+	} else {
+		t.Right.Update(d)
+	}
+	return nil
+}
+
+func (t *Tree) Search(d Valuer) (Valuer, error) {
+	if _, ok := d.(Valuer); !ok {
+		return nil, errors.New("the passed argument does not implement the interface Valuer")
+	}
+	if reflect.ValueOf(d).IsNil() {
+		return nil, errors.New("element is nil")
+	}
+	if t == nil {
+		return nil, errors.New("document not found")
+	}
+
+	if t.Value.Ident() == d.(Valuer).Ident() {
+		return t.Value, nil
+	}
+
+	if d.(Valuer).Ident() < t.Value.Ident() {
+		return t.Left.Search(d)
+	} else {
+		return t.Right.Search(d)
+	}
+}
+
+func (t *Tree) Print(depth int) (res string) {
+	if t == nil {
+		return
+	}
+	res += t.Right.Print(depth + 1)
+	for i := 0; i < depth; i++ {
+		res += "\t"
+	}
+	res += strconv.FormatUint(t.Value.Ident(), 10) + "\n"
+	res += t.Left.Print(depth + 1)
+	return res
+}
+
+func (t *Tree) String() string {
+	return "\n" + t.Print(0)
+}
+
+func isNilFixed(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+	switch reflect.TypeOf(i).Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
+		//use of IsNil method
+		return reflect.ValueOf(i).IsNil()
+	}
+	return false
+}

--- a/hw19/pkg/index/tree/btree/btree_test.go
+++ b/hw19/pkg/index/tree/btree/btree_test.go
@@ -1,0 +1,136 @@
+package btree
+
+import (
+	"fmt"
+	"gosearch/pkg/crawler"
+	"testing"
+)
+
+func TestAdd(t *testing.T) {
+	tr := New()
+
+	testCases := []struct {
+		wantErr   bool
+		ErrorText string
+		Want      *crawler.Document
+	}{
+		{
+			wantErr:   false,
+			ErrorText: "",
+			Want: &crawler.Document{
+				uint64(2),
+				"",
+				"",
+			},
+		},
+		{
+			wantErr:   false,
+			ErrorText: "",
+			Want: &crawler.Document{
+				uint64(3),
+				"",
+				"",
+			},
+		},
+		{
+			wantErr:   true,
+			ErrorText: "element already exist",
+			Want: &crawler.Document{
+				uint64(2),
+				"",
+				"",
+			},
+		},
+		{
+			wantErr:   true,
+			ErrorText: "element is nil",
+			Want:      nil,
+		},
+	}
+
+	for i, tt := range testCases {
+		err := tr.Add(tt.Want)
+		if tt.wantErr && err != nil {
+			if err.Error() != tt.ErrorText {
+				t.Fatalf("[%d] ожидалась ошибка \"%s\", а получена \"%s\"", i, tt.ErrorText, err.Error())
+			}
+		}
+
+		if tt.wantErr && err == nil {
+			t.Fatalf("[%d] ожидалась ошибка \"%s\", но ошибка не получена", i, tt.ErrorText)
+		}
+
+		if !tt.wantErr && err != nil {
+			t.Fatalf("[%d] ожидалось \"%v\", а получена ошибка \"%s\"", i, tt.Want, err.Error())
+		}
+	}
+
+	want := "\n\t3\n2\n"
+	if fmt.Sprint(tr) != want {
+		t.Fatalf("ожидалось \"%v\", а получено \"%s\"", want, tr)
+	}
+}
+
+func TestSearch(t *testing.T) {
+	tree := New()
+
+	for i := 0; i < 3; i++ {
+		err := tree.Add(&crawler.Document{ID: uint64(i), Title: "Title", URL: "URL"})
+		if err != nil {
+			t.Fatalf("ошибка добавления элемента с ID=%d в дерево: %s", i+1, err.Error())
+		}
+	}
+
+	tests := []struct {
+		wantErr   bool
+		ErrorText string
+		Want      *crawler.Document
+	}{
+		{
+			wantErr:   false,
+			ErrorText: "",
+			Want: &crawler.Document{
+				uint64(2),
+				"",
+				"",
+			},
+		},
+		{
+			wantErr:   true,
+			ErrorText: "document not found",
+			Want: &crawler.Document{
+				uint64(3),
+				"",
+				"",
+			},
+		},
+		{
+			wantErr:   true,
+			ErrorText: "element is nil",
+			Want:      nil,
+		},
+	}
+
+	for i, tt := range tests {
+		got, err := tree.Search(tt.Want)
+		if tt.wantErr && err != nil {
+			if err.Error() != tt.ErrorText {
+				t.Fatalf("[%d] ожидалась ошибка \"%s\", а получена \"%s\"", i, tt.ErrorText, err.Error())
+			}
+		}
+
+		if tt.wantErr && err == nil {
+			t.Fatalf("[%d] ожидалась ошибка \"%s\", но ошибка не получена", i, tt.ErrorText)
+		}
+
+		if !tt.wantErr && err != nil {
+			t.Fatalf("[%d] ожидалось \"%v\", а получена ошибка \"%s\"", i, tt.Want, err.Error())
+		}
+
+		if !tt.wantErr && err != nil {
+			if got.Ident() != tt.Want.Ident() {
+				t.Fatalf("[%d] ошибка поиска элемента в дереве: ожидалось \"%d\", но получили \"%d\"", i, tt.Want.Ident(), got.Ident())
+			}
+		}
+	}
+}

--- a/hw19/pkg/index/tree/btree/go.mod
+++ b/hw19/pkg/index/tree/btree/go.mod
@@ -1,0 +1,5 @@
+module btree
+
+replace gosearch/pkg/crawler => ../../../crawler
+
+go 1.15

--- a/hw19/pkg/index/tree/go.mod
+++ b/hw19/pkg/index/tree/go.mod
@@ -1,0 +1,9 @@
+module gosearch/pkg/index/inverted
+
+replace (
+	gosearch/pkg/crawler => ../../crawler
+	gosearch/pkg/index => ../index
+	gosearch/pkg/index/tree/btree => ./btree
+)
+
+go 1.15

--- a/hw19/pkg/index/tree/tree.go
+++ b/hw19/pkg/index/tree/tree.go
@@ -1,0 +1,153 @@
+// Содержит стурктуру, представляющую собой инвертированный индекс и методы этой структуры
+// для создания индекса и поиска по этому индексу
+package tree
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"unicode"
+
+	"gosearch/pkg/crawler"
+	"gosearch/pkg/index"
+	"gosearch/pkg/index/tree/btree"
+)
+
+type Tree struct {
+	index index.Index
+	docs  *btree.Tree
+}
+
+func NewTree(data []crawler.Document) *Tree {
+	var tree = btree.New()
+	var lindx = make(index.Index, len(data)*3)
+
+	for _, row := range data {
+		row.ID = rand.Uint64()
+		tree.Add(row)
+
+		for _, word := range strings.Split(row.Title, " ") {
+			trimWord := strings.ToLower(strings.TrimFunc(word, func(r rune) bool {
+				return unicode.IsPunct(r)
+			}))
+
+			if !checkOccurrence(lindx[trimWord], row.ID) && trimWord != "" {
+				lindx[trimWord] = append(lindx[trimWord], row.ID)
+			}
+		}
+	}
+
+	return &Tree{
+		lindx,
+		tree,
+	}
+}
+
+func (i *Tree) Add(url string, title string) error {
+	var row crawler.Document
+	row.ID = rand.Uint64()
+	row.Title = title
+	row.URL = url
+
+	err := i.docs.Add(row)
+	if err != nil {
+		return nil
+	}
+
+	for _, word := range strings.Split(row.Title, " ") {
+		trimWord := strings.ToLower(strings.TrimFunc(word, func(r rune) bool {
+			return unicode.IsPunct(r)
+		}))
+
+		if !checkOccurrence(i.index[trimWord], row.ID) && trimWord != "" {
+			i.index[trimWord] = append(i.index[trimWord], row.ID)
+		}
+	}
+
+	return nil
+}
+
+func (i *Tree) Delete(ID uint64) error {
+	row := crawler.Document{
+		ID: ID,
+	}
+
+	tmp, err := i.docs.Delete(row)
+	if err != nil {
+		return err
+	}
+	i.docs = tmp
+
+	return nil
+}
+
+func (i *Tree) Update(ID uint64, url, title string) error {
+	row := crawler.Document{
+		ID:    ID,
+		URL:   url,
+		Title: title,
+	}
+
+	err := i.docs.Update(row)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *Tree) Index() index.Index {
+	return i.index
+}
+
+// Возвращает слайс []crawler.Document с записями в которых найдена strings
+func (i *Tree) Find(record string) ([]crawler.Document, error) {
+	records := []crawler.Document{}
+	docs, exist := i.index[record]
+	if !exist {
+		return records, fmt.Errorf("index not found")
+	}
+
+	for _, address := range docs {
+		res, err := i.docs.Search(&crawler.Document{
+			ID:    address,
+			Title: "",
+			URL:   "",
+		})
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, res.(crawler.Document))
+	}
+	return records, nil
+}
+
+// Ищет запись uint64 в слайсе []crawler.Document по значению, являющемся полем ID в структуре crawler.Document
+func binarySearch(value uint64, source []crawler.Document) (uint64, error) {
+	left := uint64(0)
+	right := uint64(len(source) - 1)
+
+	for left <= right {
+		mID := uint64((left + right) / 2)
+
+		if value == source[mID].ID {
+			return mID, nil
+		}
+		if value < source[mID].ID {
+			right = mID - 1
+		} else {
+			left = mID + 1
+		}
+	}
+	return uint64(0), fmt.Errorf("nothing found")
+}
+
+// Возвращает true если value имеется в слайсе data, иначе false
+func checkOccurrence(data []uint64, value uint64) bool {
+	for _, val := range data {
+		if val == value {
+			return true
+		}
+	}
+	return false
+}

--- a/hw19/pkg/index/tree/tree_test.go
+++ b/hw19/pkg/index/tree/tree_test.go
@@ -1,0 +1,119 @@
+package tree
+
+import (
+	"gosearch/pkg/crawler"
+	"testing"
+)
+
+var data = []crawler.Document{
+	crawler.Document{
+		ID:    uint64(1),
+		Title: "Как использовать git?",
+		URL:   "http://localhost",
+	},
+	crawler.Document{
+		ID:    uint64(2),
+		Title: "Прикладное применение подорожника",
+		URL:   "http://localhost",
+	},
+	crawler.Document{
+		ID:    uint64(3),
+		Title: "Криптовалюта - будущее финансовой системы?",
+		URL:   "http://localhost",
+	},
+}
+
+func TestTree_Find(t *testing.T) {
+	type args struct {
+		record string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			"Тестирование поиска элемента",
+			args{
+				record: "прикладное",
+			},
+			data[1].URL,
+			false,
+		},
+		{
+			"Тестирование поиска отсутствующего элемента",
+			args{
+				record: "кек",
+			},
+			"index not found",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := NewIndexTree(data)
+			got, err := i.Find(tt.args.record)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Tree.Find() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if (err != nil) && tt.wantErr {
+				if err.Error() != tt.want {
+					t.Fatalf("Tree.Find() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+
+			if len(got) == 0 {
+				t.Fatal("len(Tree.Find()) = 0, want 1")
+			}
+			if got[0].URL != tt.want {
+				t.Errorf("Tree.Find().URL = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_binarySearch(t *testing.T) {
+	type args struct {
+		value  uint64
+		source []crawler.Document
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    uint64
+		wantErr bool
+	}{
+		{
+			"Тестирование поиска элемента",
+			args{
+				uint64(1),
+				data,
+			},
+			uint64(0),
+			false,
+		},
+		{
+			"Тестирование поиска отсутствующего элемента",
+			args{
+				uint64(10),
+				data,
+			},
+			uint64(0),
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := binarySearch(tt.args.value, tt.args.source)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("binarySearch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("binarySearch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/hw19/pkg/netsrv/go.mod
+++ b/hw19/pkg/netsrv/go.mod
@@ -1,0 +1,5 @@
+module gosearch/pkg/netsrv
+
+go 1.15
+
+replace gosearch/pkg/engine => ../engine

--- a/hw19/pkg/netsrv/netsrv.go
+++ b/hw19/pkg/netsrv/netsrv.go
@@ -1,0 +1,72 @@
+package netsrv
+
+import (
+	"bufio"
+	"gosearch/pkg/engine"
+	"net"
+	"strings"
+)
+
+type Netsrv struct {
+	host   string
+	port   string
+	engine engine.Service
+}
+
+func New(host string, port string, engine engine.Service) *Netsrv {
+	return &Netsrv{
+		host:   host,
+		port:   port,
+		engine: engine,
+	}
+}
+
+// Принимает соединение с запросом, в ответ пишет результат поиска по запросу
+func (n *Netsrv) Search(conn net.Conn) {
+	query := bufio.NewReader(conn)
+	for {
+		line, err := query.ReadString('\n')
+
+		if err != nil {
+			conn.Write([]byte("error occured:" + err.Error() + "\n"))
+			return
+		}
+
+		lineclr := strings.TrimRight(line, "\n\r")
+		if lineclr == "exit" {
+			conn.Close()
+			return
+		}
+
+		docs, err := n.engine.Search(lineclr)
+		if err != nil {
+			conn.Write([]byte("error occured:" + err.Error() + "\n"))
+			continue
+		}
+
+		for _, doc := range docs {
+			_, err := conn.Write([]byte(doc.URL + " - " + doc.Title + "\n"))
+			if err != nil {
+				conn.Write([]byte("error occured:" + err.Error() + "\n"))
+				return
+			}
+		}
+		conn.Write([]byte("done\n"))
+	}
+}
+
+func (n *Netsrv) Serve() error {
+	lstnr, err := net.Listen("tcp4", n.host+":"+n.port)
+	if err != nil {
+		return err
+	}
+
+	for {
+		conn, err := lstnr.Accept()
+		if err != nil {
+			return err
+		}
+
+		go n.Search(conn)
+	}
+}

--- a/hw19/pkg/rpcsrv/go.mod
+++ b/hw19/pkg/rpcsrv/go.mod
@@ -3,6 +3,6 @@ module gosearch/pkg/rpcsrv
 go 1.15
 
 replace (
-    gosearch/pkg/crawler => ../crawler
-    gosearch/pkg/engine => ../engine
+	gosearch/pkg/crawler => ../crawler
+	gosearch/pkg/engine => ../engine
 )

--- a/hw19/pkg/rpcsrv/go.mod
+++ b/hw19/pkg/rpcsrv/go.mod
@@ -1,0 +1,8 @@
+module gosearch/pkg/rpcsrv
+
+go 1.15
+
+replace (
+    gosearch/pkg/crawler => ../crawler
+    gosearch/pkg/engine => ../engine
+)

--- a/hw19/pkg/rpcsrv/rpcsrv.go
+++ b/hw19/pkg/rpcsrv/rpcsrv.go
@@ -1,0 +1,51 @@
+package rpcsrv
+
+import (
+	"gosearch/pkg/crawler"
+	"gosearch/pkg/engine"
+	"log"
+	"net"
+	"net/rpc"
+
+	"github.com/powerman/rpc-codec/jsonrpc2"
+)
+
+type RPCsrv struct {
+	engine *engine.Service
+}
+
+type Query struct {
+	Data string
+}
+
+func (r *RPCsrv) Search(query Query, result *[]crawler.Document) error {
+	res, err := r.engine.Search(query.Data)
+	if err != nil {
+		return err
+	}
+
+	*result = res
+	return nil
+}
+
+func Serve(host, port string, e *engine.Service) {
+	listener, err := net.Listen("tcp4", host+":"+port)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	defer listener.Close()
+
+	err = rpc.Register(&RPCsrv{e})
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Fatalf("error: %v", err)
+		}
+
+		go jsonrpc2.ServeConn(conn)
+	}
+}

--- a/hw19/pkg/rpcsrv/rpcsrv.go
+++ b/hw19/pkg/rpcsrv/rpcsrv.go
@@ -5,9 +5,9 @@ import (
 	"gosearch/pkg/engine"
 	"log"
 	"net"
-	"net/rpc"
 
-	"github.com/powerman/rpc-codec/jsonrpc2"
+	"net/rpc"
+	"net/rpc/jsonrpc"
 )
 
 type RPCsrv struct {
@@ -28,14 +28,14 @@ func (r *RPCsrv) Search(query Query, result *[]crawler.Document) error {
 	return nil
 }
 
-func Serve(host, port string, e *engine.Service) {
+func Serve(host, port string, engn *engine.Service) {
 	listener, err := net.Listen("tcp4", host+":"+port)
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
 	defer listener.Close()
 
-	err = rpc.Register(&RPCsrv{e})
+	err = rpc.Register(&RPCsrv{engn})
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
@@ -46,6 +46,6 @@ func Serve(host, port string, e *engine.Service) {
 			log.Fatalf("error: %v", err)
 		}
 
-		go jsonrpc2.ServeConn(conn)
+		go jsonrpc.ServeConn(conn)
 	}
 }

--- a/hw19/pkg/webapp/go.mod
+++ b/hw19/pkg/webapp/go.mod
@@ -1,0 +1,10 @@
+module gosearch/pkg/webapp
+
+go 1.15
+
+replace (
+	gosearch/pkg/crawler => ../crawler
+	gosearch/pkg/engine => ../engine
+	gosearch/pkg/index => ../index
+	gosearch/pkg/index/fakeindex => ../index/fakeindex
+)

--- a/hw19/pkg/webapp/webapp.go
+++ b/hw19/pkg/webapp/webapp.go
@@ -1,0 +1,86 @@
+package webapp
+
+import (
+	"gosearch/pkg/engine"
+	"net/http"
+	"text/template"
+)
+
+type WebApp struct {
+	engine engine.Service
+	host   string
+	port   string
+}
+
+func New(engine engine.Service) *WebApp {
+	wa := &WebApp{
+		engine: engine,
+	}
+
+	return wa
+}
+
+func (wa *WebApp) handlers() http.Handler {
+	r := http.NewServeMux()
+
+	r.HandleFunc("/index", wa.Index)
+	r.HandleFunc("/docs", wa.Docs)
+
+	return r
+}
+
+func (wa *WebApp) Index(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	tpl, err := template.New("index").Parse(`<ul>
+		{{ range $index, $content := . }}
+		<li><b>{{ $index }}</b> - {{ range $val := $content }}{{$val}}, {{ end }}</li>
+		{{ end }}
+		</ul>`)
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("error occured during the parsing of a template: " + err.Error()))
+		return
+	}
+
+	err = tpl.Execute(w, wa.engine.Index.Index())
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("error occured during the executing of a template: " + err.Error()))
+		return
+	}
+}
+
+func (wa *WebApp) Docs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	tpl, err := template.New("docs").Parse(`<ul>
+		{{ range . }}
+		<li><b>{{ .URL }}</b> - {{ .Title }}</li>
+		{{ end }}
+		</ul>`)
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("error occured during the parsing of a template: " + err.Error()))
+		return
+	}
+
+	err = tpl.Execute(w, wa.engine.Data)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("error occured during the executing of a template: " + err.Error()))
+		return
+	}
+}

--- a/hw19/pkg/webapp/webapp_test.go
+++ b/hw19/pkg/webapp/webapp_test.go
@@ -1,0 +1,172 @@
+package webapp
+
+import (
+	"gosearch/pkg/crawler"
+	"gosearch/pkg/engine"
+	"gosearch/pkg/index/fakeindex"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	client = &http.Client{Timeout: time.Second}
+	indx   = fakeindex.New()
+	data   = []crawler.Document{
+		crawler.Document{
+			ID:    uint64(1),
+			Title: "Как использовать git?",
+			URL:   "http://localhost",
+		},
+		crawler.Document{
+			ID:    uint64(2),
+			Title: "Прикладное применение подорожника как лекарство",
+			URL:   "http://localhost",
+		},
+		crawler.Document{
+			ID:    uint64(3),
+			Title: "Криптовалюта как будущее финансовой системы?",
+			URL:   "http://localhost",
+		},
+	}
+	engn = engine.New(indx, data)
+	host = "0.0.0.0"
+	port = "8000"
+)
+
+type Case struct {
+	Method string
+	Path   string
+	Status int
+	Result string
+}
+
+func TestIndex(t *testing.T) {
+	wa := New(*engn)
+	ts := httptest.NewServer(wa.handlers())
+	defer ts.Close()
+
+	tests := []Case{
+		{
+			Method: "GET",
+			Path:   "/index",
+			Status: http.StatusOK,
+			Result: "",
+		},
+		{
+			Method: "POST",
+			Path:   "/index",
+			Status: http.StatusMethodNotAllowed,
+			Result: "",
+		},
+		{
+			Method: "GET",
+			Path:   "/indexx",
+			Status: http.StatusNotFound,
+			Result: "page not found",
+		},
+	}
+
+	for idx, tt := range tests {
+		req, err := http.NewRequest(tt.Method, ts.URL+tt.Path, nil)
+		if err != nil {
+			t.Errorf("[%d] request generating error: %v", idx, err)
+			continue
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Errorf("[%d] request error: %v", idx, err)
+			continue
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != tt.Status {
+			t.Errorf("[%d] expected http status %v, got %v", idx, tt.Status, resp.StatusCode)
+			continue
+		}
+
+		if tt.Status != http.StatusOK {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Errorf("[%d] reading body error: %v", idx, err)
+				continue
+			}
+			sbody := string(body)
+
+			if !strings.Contains(sbody, tt.Result) {
+				t.Errorf("[%d] results not match\nGot: %#v\nExpected: %#v", idx, sbody, tt.Result)
+				continue
+			}
+		}
+	}
+}
+
+func TestDocs(t *testing.T) {
+	wa := New(*engn)
+	ts := httptest.NewServer(wa.handlers())
+	defer ts.Close()
+
+	tests := []Case{
+		{
+			Method: "GET",
+			Path:   "/index",
+			Status: http.StatusOK,
+			Result: "",
+		},
+		{
+			Method: "POST",
+			Path:   "/docs",
+			Status: http.StatusMethodNotAllowed,
+			Result: "",
+		},
+		{
+			Method: "GET",
+			Path:   "/docss",
+			Status: http.StatusNotFound,
+			Result: "page not found",
+		},
+	}
+
+	for idx, tt := range tests {
+		req, err := http.NewRequest(tt.Method, ts.URL+tt.Path, nil)
+		if err != nil {
+			t.Errorf("[%d] request generating error: %v", idx, err)
+			continue
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Errorf("[%d] request error: %v", idx, err)
+			continue
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != tt.Status {
+			t.Errorf("[%d] expected http status %v, got %v", idx, tt.Status, resp.StatusCode)
+			continue
+		}
+
+		if tt.Status != http.StatusOK {
+			// пропуск кейса в ответе на который не приходит тело
+			if tt.Result == "" {
+				continue
+			}
+
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Errorf("[%d] reading body error: %v", idx, err)
+				continue
+			}
+			sbody := string(body)
+
+			if !strings.Contains(sbody, tt.Result) {
+				t.Errorf("[%d] results not match\nGot: %#v\nExpected: %#v", idx, sbody, tt.Result)
+				continue
+			}
+		}
+	}
+}


### PR DESCRIPTION
Добавлен rpc интерактивный клиент и сервер.

Думал сделать rpc частью приложения, т.е добавить в gosearch структуру, однако этого не вышло сделать. Поскольку для rpc требуется тип с методами типа определенного формата `func (t *T) MethodName(argType T1, replyType *T2) error`. И при попытке стурктуре RPCsrv добавить метод запускающий сервер, а-ля Serve, выдает ошибку, что не прототип функции не соответствует требованиям rpc. Поэтому в пакете rpcsrv есть метод Serve, запускающий rpc-сервер.